### PR TITLE
Fix check failure when there is a wild card CNAME record

### DIFF
--- a/getssl
+++ b/getssl
@@ -1257,9 +1257,6 @@ for d in "${alldomains[@]}"; do
       if [[ -z "$AUTH_DNS_SERVER" ]]; then
         # Find authorative dns server for _acme-challenge.{domain} (for CNAMES/acme-dns)
         get_auth_dns "${rr}"
-        if test -n "${cname}"; then
-          rr=${cname}
-        fi
 
         # If no authorative dns server found, try again for {domain}
         if [[ -z "$primary_ns" ]]; then


### PR DESCRIPTION
If there is a wildcard CNAME record "*.domain.com", resolving `_acme-challenge.domain.com` would yield another domain. Getssl incorrectly updates the check domain with the resolved domain which causes check failure! 

Let's Encrypt validation does not follow CNAME of the challenge domain and Getssl should not too.